### PR TITLE
837386: do not package jna with thumbslug

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,6 +12,10 @@
   <property name="target.dir" location="${ts-home}/target" />
   <property name="lib.dir" location="${libdir}" />
   <property name="pkgname" value="org.fedoraproject.thumbslug" />
+  <property name="classpath" value="/usr/share/java/jna.jar
+                                    /usr/share/java/netty.jar
+                                    /usr/share/java/log4j.jar
+                                    /usr/share/java/commons-codec.jar" />
 
   <macrodef name="grepfromspec">
     <attribute name="text" />
@@ -84,13 +88,9 @@
         <condition>
          <not>
           <and>
-             <available file="${lib.dir}/netty.jar" type="file"/>
-             <available file="${lib.dir}/log4j.jar" type="file"/>
              <available file="${lib.dir}/akuma.jar" type="file"/>
-             <available file="${lib.dir}/jna.jar" type="file"/>
              <available file="${lib.dir}/oauth.jar" type="file"/>
              <available file="${lib.dir}/oauth-consumer.jar" type="file"/>
-             <available file="${lib.dir}/commons-codec.jar" type="file"/>
           </and>
           </not>
          </condition>
@@ -101,13 +101,9 @@
       <fileset dir="${target.dir}/resources"/>
 
       <zipgroupfileset dir="${lib.dir}">
-        <include name="netty.jar"/>
-        <include name="log4j.jar"/>
         <include name="akuma.jar"/>
-        <include name="jna.jar"/>
         <include name="oauth.jar"/>
         <include name="oauth-consumer.jar"/>
-        <include name="commons-codec.jar"/>
       </zipgroupfileset>
       <manifest>
         <attribute name="Implementation-Vendor" value="" />
@@ -118,6 +114,7 @@
         <attribute name="Implementation-Title" value="The Proxy project" />
         <attribute name="Build-Jdk" value="" />
         <attribute name="Main-Class" value="org.candlepin.thumbslug.Main" />
+        <attribute name="Class-Path" value="${classpath}" />
       </manifest>
     </jar>
     <!--

--- a/buildfile
+++ b/buildfile
@@ -34,6 +34,7 @@ define "thumbslug" do
   project.group = GROUP
   manifest["Implementation-Vendor"] = COPYRIGHT
   manifest["Main-Class"] = "org.candlepin.thumbslug.Main"
+  manifest["Class-Path"] = "/usr/share/java/jna.jar /usr/share/java/netty.jar /usr/share/java/log4j.jar /usr/share/java/commons-codec.jar"
   compile.with [NETTY, LOG4J, DAEMON, OAUTH, COMMONSCODEC]
   test.compile.with [NETTY, LOG4J, DAEMON, OAUTH, COMMONSCODEC]
   test.with [JUNIT, MOCKITO]
@@ -45,14 +46,9 @@ define "thumbslug" do
   eclipse.natures 'org.eclipse.jdt.core.javanature'
   eclipse.builders 'org.eclipse.jdt.core.javabuilder'
 
-  # include netty (and deps) in the jar, so it can run standalone
-  # we exclude the manifests of the sub-jars so they don't overwrite
-  # our own manifest.mf
-  package(:jar).merge(NETTY).exclude("META-INF/MANIFEST.MF")
-  package(:jar).merge(LOG4J).exclude("META-INF/MANIFEST.MF")
+  # these need to be removed eventually
   package(:jar).merge(DAEMON).exclude("META-INF/MANIFEST.MF")
   package(:jar).merge(OAUTH).exclude("META-INF/MANIFEST.MF")
-  package(:jar).merge(COMMONSCODEC).exclude("META-INF/MANIFEST.MF")
   package(:jar).with(:manifest => manifest)
 end
 

--- a/thumbslug.spec
+++ b/thumbslug.spec
@@ -21,6 +21,14 @@ Vendor: Red Hat, Inc.
 BuildArch: noarch
 
 Requires(pre): shadow-utils
+Requires: jakarta-commons-codec
+Requires: jna >= 3.2.4
+Requires: log4j >= 1.2
+Requires: netty >= 3.2.3
+# once these are available in fedora, they can be put here
+# and removed from build.xml inclusion
+#Requires: akuma >= 1.7
+#Requires: oauth
 
 BuildRequires: ant >= 1.7.0
 BuildRequires: akuma >= 1.7


### PR DESCRIPTION
Previously, thumbslug was being packaged with dependency jars. This did not
work for jna, since it relies on native extensions that are not compiled with
the jar.

Instead, use the jar that is supplied with the system. I also performed the
same for netty and commons-codec; I left akuma and oauth as-is for now since
system-level jars are not available on all distributions yet.
