### PR TITLE
837386: do not package jars with thumbslug

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -80,35 +80,10 @@
   </target>
 
   <target name="package" depends="compile">
-      <fail message="unable to find needed jar">
-        <condition>
-         <not>
-          <and>
-             <available file="${lib.dir}/netty.jar" type="file"/>
-             <available file="${lib.dir}/log4j.jar" type="file"/>
-             <available file="${lib.dir}/akuma.jar" type="file"/>
-             <available file="${lib.dir}/jna.jar" type="file"/>
-             <available file="${lib.dir}/oauth.jar" type="file"/>
-             <available file="${lib.dir}/oauth-consumer.jar" type="file"/>
-             <available file="${lib.dir}/commons-codec.jar" type="file"/>
-          </and>
-          </not>
-         </condition>
-      </fail>
-
     <jar destfile="${ts.jar}">
       <fileset dir="${target.dir}/classes"/>
       <fileset dir="${target.dir}/resources"/>
 
-      <zipgroupfileset dir="${lib.dir}">
-        <include name="netty.jar"/>
-        <include name="log4j.jar"/>
-        <include name="akuma.jar"/>
-        <include name="jna.jar"/>
-        <include name="oauth.jar"/>
-        <include name="oauth-consumer.jar"/>
-        <include name="commons-codec.jar"/>
-      </zipgroupfileset>
       <manifest>
         <attribute name="Implementation-Vendor" value="" />
         <attribute name="Manifest-Version" value="1.0" />

--- a/buildfile
+++ b/buildfile
@@ -9,6 +9,11 @@ VERSION_NUMBER = "1.0.0"
 GROUP = "thumbslug"
 COPYRIGHT = ""
 
+classpath = "/usr/share/java/netty.jar:/usr/share/java/log4j.jar:/usr/share/java/jna.jar"
+classpath << ":/usr/share/java/commons-codec.jar:/usr/share/java/akuma.jar"
+classpath << ":/usr/share/java/oauth/oauth.jar:/usr/share/java/oauth/oauth-consumer.jar"
+classpath << ":target/#{GROUP}-#{VERSION_NUMBER}.jar"
+
 # Specify Maven 2.0 remote repositories here, like this:
 repositories.remote << "http://mirrors.ibiblio.org/pub/mirrors/maven2/"
 repositories.remote << "https://repository.jboss.org/nexus/content/repositories/releases/"
@@ -33,7 +38,6 @@ define "thumbslug" do
   project.version = VERSION_NUMBER
   project.group = GROUP
   manifest["Implementation-Vendor"] = COPYRIGHT
-  manifest["Main-Class"] = "org.candlepin.thumbslug.Main"
   compile.with [NETTY, LOG4J, DAEMON, OAUTH, COMMONSCODEC]
   test.compile.with [NETTY, LOG4J, DAEMON, OAUTH, COMMONSCODEC]
   test.with [JUNIT, MOCKITO]
@@ -44,20 +48,11 @@ define "thumbslug" do
   #
   eclipse.natures 'org.eclipse.jdt.core.javanature'
   eclipse.builders 'org.eclipse.jdt.core.javabuilder'
-
-  # include netty (and deps) in the jar, so it can run standalone
-  # we exclude the manifests of the sub-jars so they don't overwrite
-  # our own manifest.mf
-  package(:jar).merge(NETTY).exclude("META-INF/MANIFEST.MF")
-  package(:jar).merge(LOG4J).exclude("META-INF/MANIFEST.MF")
-  package(:jar).merge(DAEMON).exclude("META-INF/MANIFEST.MF")
-  package(:jar).merge(OAUTH).exclude("META-INF/MANIFEST.MF")
-  package(:jar).merge(COMMONSCODEC).exclude("META-INF/MANIFEST.MF")
   package(:jar).with(:manifest => manifest)
 end
 
 task :serve do
-    sh "java -jar target/#{GROUP}-#{VERSION_NUMBER}.jar"
+    sh "java -cp #{classpath} org.candlepin.thumbslug.Main"
 end
 task :serve => :package
 

--- a/spec/thumbslug_common.rb
+++ b/spec/thumbslug_common.rb
@@ -80,6 +80,12 @@ module ThumbslugMethods
   end
 
   def create_thumbslug(params={})
+
+    classpath = "/usr/share/java/netty.jar:/usr/share/java/log4j.jar:/usr/share/java/jna.jar"
+    classpath << ":/usr/share/java/commons-codec.jar:/usr/share/java/akuma.jar"
+    classpath << ":/usr/share/java/oauth/oauth.jar:/usr/share/java/oauth/oauth-consumer.jar"
+    classpath << ":" + Dir.pwd + "/target/thumbslug-1.0.0.jar"
+
     #these need to all be strings
     config = {
      :port => '8088',
@@ -102,7 +108,8 @@ module ThumbslugMethods
       config[key] = value
     end
 
-    tslug_exec_string = "java " + 
+    tslug_exec_string = "java " +
+                 " -cp #{classpath}" +
                  " -Ddaemonize=false" +
                  " -Dport=" + config[:port] +
                  " -Dssl=" + config[:ssl] +
@@ -121,7 +128,7 @@ module ThumbslugMethods
                  " -Dcdn.proxy=false" +
                  #" -Dcdn.proxy.host=proxy-ip-here" +
                  #" -Dcdn.proxy.port=proxy-port-here" +
-                 " -jar " +  Dir.pwd + "/target/thumbslug-1.0.0.jar"
+                 " org.candlepin.thumbslug.Main"
     pipe = IO.popen(tslug_exec_string, "w+")
     #this is perlesque
     while pipe.gets()

--- a/thumbslug.bin
+++ b/thumbslug.bin
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-java -jar /usr/share/thumbslug/thumbslug.jar
+CLASSPATH="/usr/share/java/netty.jar:/usr/share/java/log4j.jar:/usr/share/java/jna.jar"
+CLASSPATH="$CLASSPATH:/usr/share/java/commons-codec.jar:/usr/share/java/akuma.jar"
+CLASSPATH="$CLASSPATH:/usr/share/java/oauth/oauth.jar:/usr/share/java/oauth/oauth-consumer.jar"
+CLASSPATH="$CLASSPATH:/usr/share/thumbslug/thumbslug.jar"
+
+java -cp $CLASSPATH org.candlepin.thumbslug.Main

--- a/thumbslug.init
+++ b/thumbslug.init
@@ -21,7 +21,11 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-exec="java -jar /usr/share/thumbslug/thumbslug.jar"
+CLASSPATH="/usr/share/java/netty.jar:/usr/share/java/log4j.jar:/usr/share/java/jna.jar"
+CLASSPATH="$CLASSPATH:/usr/share/java/commons-codec.jar:/usr/share/java/akuma.jar"
+CLASSPATH="$CLASSPATH:/usr/share/java/oauth/oauth.jar:/usr/share/java/oauth/oauth-consumer.jar"
+CLASSPATH="$CLASSPATH:/usr/share/thumbslug/thumbslug.jar"
+exec="java -cp $CLASSPATH org.candlepin.thumbslug.Main"
 prog=thumbslug
 config=/etc/thumbslug/thumbslug.conf
 pidfile=/var/run/thumbslug/thumbslug.pid

--- a/thumbslug.spec
+++ b/thumbslug.spec
@@ -21,6 +21,12 @@ Vendor: Red Hat, Inc.
 BuildArch: noarch
 
 Requires(pre): shadow-utils
+Requires: jakarta-commons-codec
+Requires: jna >= 3.2.4
+Requires: log4j >= 1.2
+Requires: netty >= 3.2.3
+Requires: akuma >= 1.7
+Requires: oauth
 
 BuildRequires: ant >= 1.7.0
 BuildRequires: akuma >= 1.7


### PR DESCRIPTION
Previously, thumbslug was being packaged with dependency jars. This did not
work for jna, since it relies on native extensions that are not compiled with
the jar.

Instead, use the jar that is supplied with the system. I also performed the
same for other dependency jars as well, and set the classpath in the init
script.
