### PR TITLE
865841: Improve concurrency properties of thumbslug

### DIFF
--- a/perf/README
+++ b/perf/README
@@ -1,4 +1,4 @@
 = Performance and Load Testing =
 
 concurrency test will lauch N requests each in its own thread over M
-iterations, run it like 'ruby perf/concurrency-test.rb M N'
+iterations, run it like 'ruby perf/concurrency-test.rb M N CERT PATH'

--- a/perf/concurrency-test.rb
+++ b/perf/concurrency-test.rb
@@ -14,7 +14,7 @@ require 'net/https'
 
 TS_SERVER = "localhost"
 TS_PORT = 8088
-TS_FILE = "/"
+TS_FILE = ARGV[3]
 
 def debug(msg)
   STDERR.write Thread.current[:name]
@@ -29,9 +29,8 @@ def grab_file(server, port)
   client = Net::HTTP.new server, port
   client.use_ssl = true
   client.verify_mode = OpenSSL::SSL::VERIFY_NONE #TODO: verify server
-  client.ca_file = "CA/cacert.pem"
-  client.key = OpenSSL::PKey::RSA.new(File.read("spec/data/spec/spec-client_keypair.pem"))
-  client.cert = OpenSSL::X509::Certificate.new(File.read("spec/data/spec/cert_spec-client.pem"))
+  client.key = OpenSSL::PKey::RSA.new(File.read(ARGV[2]))
+  client.cert = OpenSSL::X509::Certificate.new(File.read(ARGV[2]))
   
   client.request_get(TS_FILE) do |response|
     response.read_body do |segment|

--- a/src/main/java/org/candlepin/thumbslug/HttpRequestHandler.java
+++ b/src/main/java/org/candlepin/thumbslug/HttpRequestHandler.java
@@ -22,6 +22,7 @@ import org.candlepin.thumbslug.ssl.SslPemException;
 
 import org.apache.log4j.Logger;
 import org.jboss.netty.channel.Channel;
+import org.jboss.netty.channel.ChannelFactory;
 import org.jboss.netty.channel.ChannelFuture;
 import org.jboss.netty.channel.ChannelFutureListener;
 import org.jboss.netty.channel.ChannelHandlerContext;
@@ -61,10 +62,13 @@ class HttpRequestHandler extends SimpleChannelUpstreamHandler {
 
     private Config config;
     private HttpCdnClientChannelFactory clientFactory;
+    private ChannelFactory channelFactory;
 
-    HttpRequestHandler(Config config, HttpCdnClientChannelFactory clientFactory) {
+    HttpRequestHandler(Config config, HttpCdnClientChannelFactory clientFactory,
+        ChannelFactory channelFactory) {
         this.config = config;
         this.clientFactory = clientFactory;
+        this.channelFactory = channelFactory;
     }
 
     @Override
@@ -162,7 +166,7 @@ class HttpRequestHandler extends SimpleChannelUpstreamHandler {
                         sendResponseToClient(ctx, HttpResponseStatus.BAD_GATEWAY);
                     }
 
-                });
+                }, channelFactory);
 
             client.getSubscriptionCertificateViaEntitlementId(entitlementUuid);
         }


### PR DESCRIPTION
This patch contains a number of fixes for how we use netty in thumbslug:
- Use a single thread pool across all of the pipeline factories. This
  maintains a lower number of threads, and helps with caching/reuse of
  the threads
- Insert an OrderedMemoryAwareThreadPoolExecutor into the server
  pipline, to instruct netty that the end of our pipeline can block, to
  allow it to reuse the thread while the blocking occurs.
- Perform proper reuse of our SSL related objects.
