### PR TITLE
817599: Fix closing connections when in a bad state

### DIFF
--- a/src/main/java/org/candlepin/thumbslug/HttpCandlepinClient.java
+++ b/src/main/java/org/candlepin/thumbslug/HttpCandlepinClient.java
@@ -138,7 +138,7 @@ class HttpCandlepinClient {
         }
     }
 
-    public void getSubscriptionCertificateViaEntitlementId(final String entitlementId) {
+    Channel getSubscriptionCertificateViaEntitlementId(final String entitlementId) {
         Channel requestChannel = channelFactory.newChannel(getPipeline());
         // Set up the event pipeline factory.
 
@@ -153,6 +153,8 @@ class HttpCandlepinClient {
                     future.getChannel(), entitlementId);
             }
         });
+
+        return requestChannel;
     }
 
     private void onSubscriptionCertificateViaEntitlementId(Channel channel,


### PR DESCRIPTION
This patch implements a number of changes to close out our three
possible connections (client, candlepin, cdn) properly, and to ensure
the correct message reaches the client for a thumbslug/candlepin
misconfiguration.

The primary change is to add a listener for closed connections to the
client, and to have that listener close down any open connections to
candlepin or the cdn. With this listener in place, we just have to close
the client connection whenever something bad happens when talking to
candlepin or the cdn.
