### PR TITLE
924349: fix selinux warnings

### DIFF
--- a/thumbslug.spec
+++ b/thumbslug.spec
@@ -164,7 +164,7 @@ do
   /usr/sbin/semodule -s ${selinuxvariant} -i \
     %{_datadir}/selinux/${selinuxvariant}/%{modulename}.pp &> /dev/null || :
 done
-RC=0; semanage port -l | grep 8088 &> /dev/null || RC=$?
+RC=0; /usr/sbin/semanage port -l | grep 8088 &> /dev/null || RC=$?
 if [ "$RC" -ne "0" ] ; then
     /usr/sbin/semanage port -a -t thumbslug_port_t -p tcp 8088 || :
 fi


### PR DESCRIPTION
removed restorecon /var/cache/thumbslug and changed semanage -a to -d in postun.

Thumbslug makes no use of /var/cache/thumbslug. I suspect this was a copy paste error from the example SELinux packaging drafts:

http://fedoraproject.org/wiki/PackagingDrafts/SELinux 

where it makes reference to /var/cache/myapp

the uninstall post script was trying to ADD the thumbslug port instead of deleting it. The -d option seems to follow the SELinux packaging guideline for uninstall post scripts.
