### PR TITLE
924349: fix selinux warnings

### DIFF
--- a/thumbslug.spec
+++ b/thumbslug.spec
@@ -164,7 +164,7 @@ do
   /usr/sbin/semodule -s ${selinuxvariant} -i \
     %{_datadir}/selinux/${selinuxvariant}/%{modulename}.pp &> /dev/null || :
 done
-/usr/sbin/semanage port -a -t thumbslug_port_t -p tcp 8088 || :
+/usr/sbin/semanage port -a -t thumbslug_port_t -p tcp 8088 &> /dev/null || :
 
 %postun selinux
 if [ $1 -eq 0 ] ; then
@@ -172,7 +172,7 @@ if [ $1 -eq 0 ] ; then
   do
      /usr/sbin/semodule -s ${selinuxvariant} -r %{modulename} &> /dev/null || :
   done
-  /usr/sbin/semanage port -a -t thumbslug_port_t -p tcp 8088 || :
+  /usr/sbin/semanage port -d -t thumbslug_port_t -p tcp 8088 &> /dev/null || :
 fi
 
 


### PR DESCRIPTION
removed restorecon /var/cache/thumbslug and changed semanage -a to -d in postun.

Thumbslug makes no use of /var/cache/thumbslug. I suspect this was a copy paste error from the example SELinux packaging drafts:

http://fedoraproject.org/wiki/PackagingDrafts/SELinux

where it makes reference to /var/cache/myapp

the uninstall post script was trying to ADD the thumbslug port instead of deleting it. The -d option seems to follow the SELinux packaging guideline for uninstall post scripts.
