### PR TITLE
910077: Removed offending Shutting down log statement.

### DIFF
--- a/src/main/java/org/candlepin/thumbslug/Main.java
+++ b/src/main/java/org/candlepin/thumbslug/Main.java
@@ -117,7 +117,7 @@ public class Main {
         }
         catch (Exception e) {
             log.error("Unable to load config!", e);
-            log.warn("Shutting down...");
+            log.warn("Unable to load config! Shutting down...");
             System.exit(ERROR_NO_CONFIG);
         }
 
@@ -135,7 +135,7 @@ public class Main {
             }
             catch (Exception e) {
                 log.error("Exception caught during daemon initialization!", e);
-                log.warn("Shutting down...");
+                log.warn("Error during daemon initialization! Shutting down...");
                 System.exit(ERROR_DAEMON_INIT);
             }
         }
@@ -150,7 +150,6 @@ public class Main {
                     log.error("Unable to daemonize properly", e);
                     System.exit(ERROR_DAEMON_DAEMONIZE);
                 }
-                log.warn("Shutting down...");
                 System.exit(0);
             }
         }
@@ -178,7 +177,7 @@ public class Main {
 
         ALL_CHANNELS.add(channel);
 
-        //intercept shutdown signal from VM and shut-down gracefully.
+        // intercept shutdown signal from VM and shut-down gracefully.
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
             public void run() {
                 log.warn("Shutting down...");


### PR DESCRIPTION
Added text to each of the remaining Shutting down log entries which
result from an error during startup. The only one that print
Shutting down... alone is the shutdown hook which is the normal
shutdown mechanism for thumbslug.

Configuration error results int he following:
    "Unable to load config! Shutting down..."

Problem trying to daemonize:
    "Error during daemon initialization! Shutting down..."

Valid shutdown message:
    "Shutting down..."
