### PR TITLE
Fixes BZ#1528512 - Add "Host" header to proxy CONNECT request.

### DIFF
--- a/src/main/java/org/candlepin/thumbslug/HttpConnectProxy.java
+++ b/src/main/java/org/candlepin/thumbslug/HttpConnectProxy.java
@@ -74,6 +74,8 @@ public class HttpConnectProxy extends SimpleChannelUpstreamHandler {
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1,
             HttpMethod.CONNECT, uri);
 
+        request.addHeader("Host", uri);
+
         if (proxyAuth != null) {
             request.addHeader("Proxy-authorization", "Basic " +
                 new String(Base64.encodeBase64(proxyAuth.getBytes())));


### PR DESCRIPTION
Proposed fix for BZ#1528512

It seems that certain proxies expect a "Host" header to be included in the initial CONNECT request. Which, according to RFC2730 appears to be expected behavior:

https://tools.ietf.org/html/rfc7230#section-5.4

> A client MUST send a Host header field in all HTTP/1.1 request messages.

Or according to the now obsoleted RFC2616:

https://tools.ietf.org/html/rfc2616#section-14.23

> A client MUST include a Host header field in all HTTP/1.1 request
messages . If the requested URI does not include an Internet host
name for the service being requested, then the Host header field MUST
be given with an empty value. An HTTP/1.1 proxy MUST ensure that any
request message it forwards does contain an appropriate Host header
field that identifies the service being requested by the proxy. All
Internet-based HTTP/1.1 servers MUST respond with a 400 (Bad Request)
status code to any HTTP/1.1 request message which lacks a Host header
field.

Although RFC7231 does not make specific mention of required headers when making a CONNECT request:

https://tools.ietf.org/html/rfc7231#section-4.3.6

Otherwise, the proxy will complain:

MIMEsweeper Web Appliance - Access Denied
Bad request
HTTP status code: 400
The following error has occurred whilst attempting to process the requested URL.
Description	The HTTP/1.1 request does not contain a Host header.
HTTP Status Code	400
HTTP Reason Phrase	Bad request